### PR TITLE
[feature] add invoice client, service and translator

### DIFF
--- a/src/Client/Invoice/Enum/InvoiceStatus.php
+++ b/src/Client/Invoice/Enum/InvoiceStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace J3dyy\RsIntegrationWrapper\Client\Invoice\Enum;
+
+enum InvoiceStatus: int
+{
+    case DELETED = -1;
+    case SAVED = 0;
+    case SENT = 1;
+    case CONFIRMED = 2;
+    case CORRECTED_PRIMARY = 3;
+    case CORRECTOR = 4;
+    case CORRECTOR_SENT = 5;
+    case SENT_CANCELLED = 6;
+    case CANCELLATION_CONFIRMED = 7;
+    case CORRECTION_CONFIRMED = 8;
+}

--- a/src/Client/Invoice/InvoiceClient.php
+++ b/src/Client/Invoice/InvoiceClient.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace J3dyy\RsIntegrationWrapper\Client\Invoice;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\HandlerStack;
+use J3dyy\RsIntegrationWrapper\Client\IClient;
+use J3dyy\RsIntegrationWrapper\Client\RSResponse;
+use J3dyy\RsIntegrationWrapper\Exceptions\RSIntegrationException;
+
+class InvoiceClient implements IClient
+{
+    protected GuzzleClient $client;
+
+    public function __construct(?callable $handlerStack = null)
+    {
+        $stack = HandlerStack::create($handlerStack);
+        $this->client = new GuzzleClient([
+            'base_uri' => 'https://www.revenue.mof.ge/ntosservice/ntosservice.asmx',
+            'handler' => $stack,
+            'headers' => [
+                'Content-Type' => 'text/xml; charset=UTF-8',
+            ]
+        ]);
+    }
+
+    /**
+     * @throws RSIntegrationException
+     */
+    function request(string $method, string $endpoint, array $options = []): RSResponse
+    {
+        try {
+            return RSResponse::from(
+                $this->client->request($method, '?op=' . $endpoint, $options), 'invoice'
+            );
+        } catch (GuzzleException $exception) {
+            throw new RSIntegrationException(
+                $exception->getMessage(),
+                $exception->getCode()
+            );
+        }
+    }
+}

--- a/src/Client/Invoice/InvoiceTranslator.php
+++ b/src/Client/Invoice/InvoiceTranslator.php
@@ -6,7 +6,7 @@ use J3dyy\RsIntegrationWrapper\Client\Invoice\Enum\InvoiceStatus;
 
 class InvoiceTranslator
 {
-    public static function chek(string $username, string $password, ?int $userId = null): string
+    public static function check(string $username, string $password, ?int $userId = null): string
     {
         return self::inject('
             <chek xmlns="http://tempuri.org/">

--- a/src/Client/Invoice/InvoiceTranslator.php
+++ b/src/Client/Invoice/InvoiceTranslator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace J3dyy\RsIntegrationWrapper\Client\Invoice;
+
+use J3dyy\RsIntegrationWrapper\Client\Invoice\Enum\InvoiceStatus;
+
+class InvoiceTranslator
+{
+    public static function chek(string $username, string $password, ?int $userId = null): string
+    {
+        return self::inject('
+            <chek xmlns="http://tempuri.org/">
+                <su>' . $username . '</su>
+                <sp>' . $password . '</sp>
+                ' . ($userId !== null ? '<user_id>' . $userId . '</user_id>' : '') . '
+            </chek>
+        ');
+    }
+
+    public static function changeInvoiceStatus(
+        string $username,
+        string $password,
+        int $userId,
+        int $invId,
+        InvoiceStatus $status,
+    ): string
+    {
+        return self::inject('
+            <change_invoice_status xmlns="http://tempuri.org/">
+                <user_id>' . $userId . '</user_id>
+                <inv_id>' . $invId . '</inv_id>
+                <status>' . $status->value . '</status>
+                <su>' . $username . '</su>
+                <sp>' . $password . '</sp>
+            </change_invoice_status>
+        ');
+    }
+
+    public static function inject(string $body): string
+    {
+        return '
+        <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+            <soap:Body>
+            ' . $body . '
+            </soap:Body>
+        </soap:Envelope>
+        ';
+    }
+}

--- a/src/Client/Invoice/Service/InvoiceService.php
+++ b/src/Client/Invoice/Service/InvoiceService.php
@@ -15,12 +15,12 @@ class InvoiceService
     {
     }
 
-    public function chek(string $username, string $password, ?int $userId = null): IRSResponse
+    public function check(string $username, string $password, ?int $userId = null): IRSResponse
     {
         return $this->executeInvoiceApi(
             'chek',
             'POST',
-            InvoiceTranslator::chek($username, $password, $userId)
+            InvoiceTranslator::check($username, $password, $userId)
         );
     }
 

--- a/src/Client/Invoice/Service/InvoiceService.php
+++ b/src/Client/Invoice/Service/InvoiceService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace J3dyy\RsIntegrationWrapper\Client\Invoice\Service;
+
+use J3dyy\RsIntegrationWrapper\Client\IClient;
+use J3dyy\RsIntegrationWrapper\Client\Invoice\Enum\InvoiceStatus;
+use J3dyy\RsIntegrationWrapper\Client\Invoice\InvoiceTranslator;
+use J3dyy\RsIntegrationWrapper\Client\IRSResponse;
+use J3dyy\RsIntegrationWrapper\Client\RSResponse;
+use J3dyy\RsIntegrationWrapper\Exceptions\RSIntegrationException;
+
+class InvoiceService
+{
+    public function __construct(protected IClient $client)
+    {
+    }
+
+    public function chek(string $username, string $password, ?int $userId = null): IRSResponse
+    {
+        return $this->executeInvoiceApi(
+            'chek',
+            'POST',
+            InvoiceTranslator::chek($username, $password, $userId)
+        );
+    }
+
+    public function changeInvoiceStatus(
+        string $username,
+        string $password,
+        int $userId,
+        int $invId,
+        InvoiceStatus $status,
+    ): IRSResponse
+    {
+        return $this->executeInvoiceApi(
+            'change_invoice_status',
+            'POST',
+            InvoiceTranslator::changeInvoiceStatus($username, $password, $userId, $invId, $status)
+        );
+    }
+
+    protected function executeInvoiceApi(string $endpoint, string $method = 'GET', string $payload = '', array $headers = []): IRSResponse
+    {
+        try {
+            return $this->client->request($method, $endpoint, [
+                'body' => $payload,
+                'headers' => $headers,
+            ]);
+        } catch (RSIntegrationException $exception) {
+            return new RSResponse(
+                ['message' => $exception->getMessage()],
+                $exception->getCode(),
+                []
+            );
+        }
+    }
+}

--- a/src/Client/RSResponse.php
+++ b/src/Client/RSResponse.php
@@ -26,6 +26,10 @@ class RSResponse implements IRSResponse
                 $r = strtr($response->getBody()->getContents(), ['</soap:' => '</', '<soap:' => '<']);
                 $data = (array)json_decode(json_encode(simplexml_load_string($r)));
                 break;
+            case 'invoice':
+                $r = strtr($response->getBody()->getContents(), ['</soap:' => '</', '<soap:' => '<']);
+                $data = (array)json_decode(json_encode(simplexml_load_string($r)));
+                break;
         }
 
 

--- a/src/RS.php
+++ b/src/RS.php
@@ -5,6 +5,8 @@ namespace J3dyy\RsIntegrationWrapper;
 
 use J3dyy\RsIntegrationWrapper\Client\EApiClient;
 use J3dyy\RsIntegrationWrapper\Client\IClient;
+use J3dyy\RsIntegrationWrapper\Client\Invoice\InvoiceClient;
+use J3dyy\RsIntegrationWrapper\Client\Invoice\Service\InvoiceService;
 use J3dyy\RsIntegrationWrapper\Client\IRSResponse;
 use J3dyy\RsIntegrationWrapper\Client\RSResponse;
 use J3dyy\RsIntegrationWrapper\Client\WayBill\Enum\RSService;
@@ -19,20 +21,19 @@ class RS
     public function __construct(
         protected IClient $eApiClient,
         protected IClient $wayBillClient,
-        protected IClient $publicRsClient
+        protected IClient $publicRsClient,
+        protected IClient $invoiceClient,
     )
     {
     }
 
-    /**
-     * @return RS
-     */
     public static function default(): RS
     {
         return new RS(
             new EApiClient(),
             new WayBillClient(),
-            new XDataRS()
+            new XDataRS(),
+            new InvoiceClient(),
         );
     }
 
@@ -41,9 +42,10 @@ class RS
         $service = null;
         switch ($rsService){
             case RSService::WAYBILL:
-                $service =  new WayBillService(
-                    $this->wayBillClient
-                );
+                $service = new WayBillService($this->wayBillClient);
+                break;
+            case RSService::INVOICE:
+                $service = new InvoiceService($this->invoiceClient);
                 break;
             default:
                 throw new RsIntegrationException(sprintf("service %s not iplemented", $rsService->value));


### PR DESCRIPTION
## Summary
- Add `InvoiceClient`, `InvoiceService`, `InvoiceTranslator`, and `InvoiceStatus` enum under `src/Client/Invoice/`
- Wire new `invoiceClient` into `RS` constructor and `RS::default()`
- Handle `INVOICE` case in the `RS` service switch and `invoice` case in `RSResponse`

## Test plan
- [ ] Invoke `RS::default()->service(RSService::INVOICE)` and exercise invoice flow against RS
- [ ] Verify response parsing for `invoice` type in `RSResponse`